### PR TITLE
[Done] Improving modal injection method by injecting into the user panel's React component instead of using DOM

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "discordID": "285329659023851520",
     "github": "Socketlike"
   },
-  "version": "1.2.5",
+  "version": "1.2.4",
   "updater": {
     "type": "github",
     "id": "Socketlike/SpotifyModal"

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "discordID": "285329659023851520",
     "github": "Socketlike"
   },
-  "version": "1.2.3",
+  "version": "1.2.5",
   "updater": {
     "type": "github",
     "id": "Socketlike/SpotifyModal"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SpotifyModal",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "A Post-SWC Replugged plugin that shows a little modal on your user dock that lets you see & control what you're playing on Spotify.",
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SpotifyModal",
-  "version": "1.2.5",
+  "version": "1.2.4",
   "description": "A Post-SWC Replugged plugin that shows a little modal on your user dock that lets you see & control what you're playing on Spotify.",
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
Once implemented, this will fix:
- Modal disappearing after changing Discord's language (or any update to the entire React DOM in general)

Currently there is no way to get the user panel's React component to patch it on startup (the component itself is defined in a function)  
The only option is to wait for Discord to fully load; then we can get the instance and patch its render function  
This might end up more janky than the DOM method  
